### PR TITLE
Add manifest url to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A Foundry VTT module that provides quick-access tools for adjusting drawing prop
 
 **Compatibility:** Foundry VTT v13
 
+**Installation:** Browse for "Boneyard Drawing Tools" in the module browser, or [directly copy the manifest link for the latest release](https://github.com/operation404/boneyard-drawing-tools/releases/latest/download/module.json).
+
+
 - [Quick Drawing Settings](#quick-drawing-settings)
 - [Stroke and Fill Settings](#stroke-and-fill-settings)
 - [Color Selector](#color-selector)


### PR DESCRIPTION
Very minor addition to the README to make downloading the latest version easier. 

When downloading via module browser, I got version 2.x, which is incompatible with Foundry v13. The latest version of Boneyard Drawing Tools (3.x) is available only via manifest URL, which I had to compose by guessing the usual pattern.

This would also help resolve the specific question in this issue: https://github.com/operation404/boneyard-drawing-tools/issues/9#issuecomment-3977092402

I lifted this language directly from the [Precise Drawing Tools readme](https://github.com/shemetz/precise-drawing-tools).